### PR TITLE
master: Resolve blank map when running compiled with latest cordova-android (which uses AGP 4.1.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cordova GoogleMaps plugin for Android, iOS and Browser v2.7.0
+# Cordova GoogleMaps plugin for Android, iOS and Browser v2.7.1
 
 | Download | Build test (multiple_maps branch)|
 |----------|---------------------------|
@@ -112,6 +112,10 @@ For browser platform,
 ---------------------------------------------------------------------------------------------------------
 
 ## Release Notes
+
+  - **v2.7.1**
+    - Fix: (iOS) UiWebView references present in v2.7.0
+
   - **v2.7.0**
     - Re-adoption: <a href="https://github.com/mapsplugin/cordova-plugin-googlemaps-sdk" target="_blank">cordova-plugin-googlemaps-sdk dependency</a>
     - Important update: No longer support `UIWebView` on iOS. `WKWebView` only.
@@ -137,20 +141,6 @@ For browser platform,
     - Fix: (Android) Can't load marker image from the Internet
     - many bug fixes...
 
-  - **v2.6.2**
-    - Fix: (Android) build error
-
-  - **v2.6.1**
-    - Fix: (Android) Conflicting with `OneSignal-Cordova-SDK`
-    - Fix: (iOS) App crashes when marker url isn't valid.
-
-  - **v2.6.0**
-    - Fix: Can not install to Cordova 9.0 project
-    - Fix: (Android) `ConcurrentModificationException` error at `onStop`
-    - Fix: (Android) Polygon becomes visible when you run `setPoints()` to invisible polygon
-    - Fix: (Android/iOS) TileOverlay does not work when your app runs on `file:` protocol with ionic.
-    - Update: (iOS) Specify the Google Maps SDK version as `=> 3.1.0`. Please use `cordova-ios@5.0.0` or above, otherwise modify `platform/ios/Podfile`.
-    - Add: (Android/iOS) API Key mechanism
 
 ---------------------------------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For browser platform,
 
 ## Install optional variables (config.xml)
 
-  - ![](https://raw.githubusercontent.com/mapsplugin/cordova-plugin-googlemaps/master/images/icon-android.png) **PLAY_SERVICES_VERSION = (15.0.1)**<br>
+  - ![](https://raw.githubusercontent.com/mapsplugin/cordova-plugin-googlemaps/master/images/icon-android.png) **GOOGLE_MAPS_PLAY_SERVICES_VERSION = (16.0.1)**<br>
     The Google Play Services SDK version.
     _You need to specify the same version number with all other plugins._
     Check out the latest version [here](https://developers.google.com/android/guides/releases).

--- a/README.md
+++ b/README.md
@@ -37,15 +37,38 @@
 
 ## Quick install
 
-  - *Stable version(npm)*
-    ```
-    $> cordova plugin add cordova-plugin-googlemaps
-    ```
+  ```
+  $> cordova plugin add cordova-plugin-googlemaps
+  ```
 
-  - *Development version(beta version)*
-    ```
-    $> cordova plugin add https://github.com/mapsplugin/cordova-plugin-googlemaps#multiple_maps
-    ```
+Then set your Google Maps API keys into your `config.xml` (Android / iOS).
+
+  ```xml
+  <widget ...>
+    <preference name="GOOGLE_MAPS_ANDROID_API_KEY" value="(api key)" />
+    <preference name="GOOGLE_MAPS_IOS_API_KEY" value="(api key)" />
+  </widget>
+  ```
+
+For browser platform,
+
+  ```js
+  // If your app runs this program on browser,
+  // you need to set `API_KEY_FOR_BROWSER_RELEASE` and `API_KEY_FOR_BROWSER_DEBUG`
+  // before `plugin.google.maps.Map.getMap()`
+  //
+  //   API_KEY_FOR_BROWSER_RELEASE for `https:` protocol
+  //   API_KEY_FOR_BROWSER_DEBUG for `http:` protocol
+  //
+  plugin.google.maps.environment.setEnv({
+    'API_KEY_FOR_BROWSER_RELEASE': '(YOUR_API_KEY_IS_HERE)',
+    'API_KEY_FOR_BROWSER_DEBUG': ''  // optional
+  });
+
+  // Create a Google Maps native view under the map_canvas div.
+  var map = plugin.google.maps.Map.getMap(div);
+
+  ```
 
 ## PhoneGap Build settings
 
@@ -60,7 +83,7 @@
   </widget>
   ```
 
-## Install optional variables
+## Install optional variables (config.xml)
 
   - ![](https://raw.githubusercontent.com/mapsplugin/cordova-plugin-googlemaps/master/images/icon-android.png) **PLAY_SERVICES_VERSION = (15.0.1)**<br>
     The Google Play Services SDK version.
@@ -80,121 +103,6 @@
 
 ---------------------------------------------------------------------------------------------------------
 
-## Browser platform
-
-  We support browser platform now!
-  You can develop your application with browser, then run it!
-  At the end of development, you can upload the html files to your server, or run it on Android or iOS devices.
-
-  ```
-  $> cordova run browser
-  ```
-
-  If you use [ionic framework](https://ionicframework.com/), it supports `live-reload`.
-
-  ```
-  $> ionic cordova run browser -l
-  ```
-
-  If you want to use `live-reload`, but you don't want to use other framework or without framework,
-  [cordova-plugin-browsersync](https://www.npmjs.com/package/cordova-plugin-browsersync) is useful.
-
-  ```
-  $> cordova plugin add cordova-plugin-browsersync
-
-  $> cordova run (browser/android/ios) -- --live-reload
-  ```
-
-
-### API key (Android and iOS platforms)
-
-  As of v2.6.0, you need to specify your API keys in `config.xml` file instead of `--variable`.
-  This allows you to change your API keys for anytime without reinstallation.
-
-  Please pay attention the variable names are changed.
-
-  ```xml
-  <widget ...>
-    <preference name="GOOGLE_MAPS_ANDROID_API_KEY" value="(api key)" />
-    <preference name="GOOGLE_MAPS_IOS_API_KEY" value="(api key)" />
-  </widget>
-  ```
-
-### API key (Browser platform)
-
-  In the browser platform, the maps plugin uses [Google Maps JavaScript API v3](https://developers.google.com/maps/documentation/javascript/)
-
-  You need to set **two API keys for Google Maps JavaScript API v3**.
-
-  ```js
-  // If your app runs this program on browser,
-  // you need to set `API_KEY_FOR_BROWSER_RELEASE` and `API_KEY_FOR_BROWSER_DEBUG`
-  // before `plugin.google.maps.Map.getMap()`
-  //
-  //   API_KEY_FOR_BROWSER_RELEASE for `https:` protocol
-  //   API_KEY_FOR_BROWSER_DEBUG for `http:` protocol
-  //
-  plugin.google.maps.environment.setEnv({
-    'API_KEY_FOR_BROWSER_RELEASE': '(YOUR_API_KEY_IS_HERE)',
-    'API_KEY_FOR_BROWSER_DEBUG': ''
-  });
-
-  // Create a Google Maps native view under the map_canvas div.
-  var map = plugin.google.maps.Map.getMap(div);
-
-  ```
-
-### Why **two API keys**?
-
-  `JavaScript` code is `text code`. Even if you do obfuscation, it's still readable finally.
-  In order to protect your API key, you need to set `Key restriction` for these keys.
-
-  ![](https://raw.githubusercontent.com/mapsplugin/cordova-plugin-googlemaps/master/images/api_key_restrictions.png)
-
-  If you don't set API key, the maps plugin still work with `development mode`.
-
-  ```js
-  plugin.google.maps.environment.setEnv({
-    'API_KEY_FOR_BROWSER_RELEASE': '(YOUR_API_KEY_IS_HERE)',
-    'API_KEY_FOR_BROWSER_DEBUG': '' // If key is empty or unset,
-                                    // the maps plugin runs under the development mode.
-  });
-  ```
-  <img src="https://raw.githubusercontent.com/mapsplugin/cordova-plugin-googlemaps/master/images/development_mode.png" width="300">
-
-### Which browser supported?
-
-  Modern browsers should work without any problem.
-
-  ![](https://raw.githubusercontent.com/mapsplugin/cordova-plugin-googlemaps/master/images/modern_browsers.png)
-
-  Internet Explorer 11 might work. We don't confirm all features, but basic features work.
-
-### Behavior differences
-
-  `Google Maps JavaScript API v3` is completely different ecosystem with `Google Maps Android API` and `Google Maps SDK for iOS`.
-
-  `Google Maps JavaScript API v3` :
-  - **can't** draw 3D building,
-  - **does't work** if offline,
-  - **can't** map rotation,
-  - etc...
-
-  In the browser platform, the maps plugin works almost the same behaviors as native platforms(Android, and iOS),
-  but not exactly the same behaviors.
-  So don't expect too much.
-
-### Touch mechanism difference
-
-  As you may know, [this plugin displays native Google Maps view under the browser in Android and iOS](#how-does-this-plugin-work-android-ios).
-  However this plugin displays as `normal HTML element` in browser platform.
-
-  Because of this, touch behavior is different.
-  The maps plugin does not hook the touch position, do not set `background: transparent`, ... etc.
-  But if you use this plugin as normal behavior, you don't need to consider about this.
-
----------------------------------------------------------------------------------------------------------
-
 ## Please support this plugin activity.
 
   In order to keep this plugin as free, please consider to donate little amount for this project.
@@ -206,6 +114,7 @@
 ## Release Notes
   - **v2.7.0**
     - Re-adoption: <a href="https://github.com/mapsplugin/cordova-plugin-googlemaps-sdk" target="_blank">cordova-plugin-googlemaps-sdk dependency</a>
+    - Important update: No longer support `UIWebView` on iOS. `WKWebView` only.
     - Fix: (iOS) Can't load image files from local host on ionic 4 / 5
     - Update: (Android) prevent null pointer error in AsyncLoadImage.java
     - Fix: Css animation interference when call setDiv and there is a push/pop page
@@ -225,7 +134,8 @@
     - Remove promise-7.0.4-min.js.map
     - Fix: (iOS) bug fix: App crashes if "bearing" property is "<null>"
     - Fix: HTMLColor2RGBA() converts to incorrect value
-    - Fix: (Android) Can't load marker image from the Ineternet
+    - Fix: (Android) Can't load marker image from the Internet
+    - many bug fixes...
 
   - **v2.6.2**
     - Fix: (Android) build error

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-googlemaps",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Google Maps native SDK for Android and iOS, and Google Maps JavaScript API v3 for browser.",
   "cordova": {
     "id": "cordova-plugin-googlemaps",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-googlemaps",
-  "version": "2.7.0-20200330-2338",
+  "version": "2.7.0",
   "description": "Google Maps native SDK for Android and iOS, and Google Maps JavaScript API v3 for browser.",
   "cordova": {
     "id": "cordova-plugin-googlemaps",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-googlemaps" version="2.7.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-googlemaps" version="2.7.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>cordova-plugin-googlemaps</name>
   <js-module name="Promise" src="www/Promise.js" />
   <js-module name="BaseClass" src="www/BaseClass.js">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-googlemaps" version="2.7.0-20200330-2338" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-googlemaps" version="2.7.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>cordova-plugin-googlemaps</name>
   <js-module name="Promise" src="www/Promise.js" />
   <js-module name="BaseClass" src="www/BaseClass.js">

--- a/src/android/plugin/google/maps/CordovaGoogleMaps.java
+++ b/src/android/plugin/google/maps/CordovaGoogleMaps.java
@@ -448,15 +448,13 @@ public class CordovaGoogleMaps extends CordovaPlugin implements ViewTreeObserver
     //------------------------------------------
     JSONObject meta = args.getJSONObject(0);
     String mapId = meta.getString("__pgmId");
-    PluginMap pluginMap = new PluginMap();
-    pluginMap.privateInitialize(mapId, cordova, webView, null);
-    pluginMap.initialize(cordova, webView);
-    pluginMap.mapCtrl = CordovaGoogleMaps.this;
-    pluginMap.self = pluginMap;
 
+    PluginMap pluginMap = new PluginMap();
     PluginEntry pluginEntry = new PluginEntry(mapId, pluginMap);
     pluginManager.addService(pluginEntry);
 
+    pluginMap.mapCtrl = CordovaGoogleMaps.this;
+    pluginMap.self = pluginMap;
     pluginMap.getMap(args, callbackContext);
   }
 

--- a/src/android/plugin/google/maps/CordovaGoogleMaps.java
+++ b/src/android/plugin/google/maps/CordovaGoogleMaps.java
@@ -468,14 +468,12 @@ public class CordovaGoogleMaps extends CordovaPlugin implements ViewTreeObserver
     String mapId = meta.getString("__pgmId");
     Log.d(TAG, "---> mapId = " + mapId);
     PluginStreetViewPanorama pluginStreetView = new PluginStreetViewPanorama();
-    pluginStreetView.privateInitialize(mapId, cordova, webView, null);
-    pluginStreetView.initialize(cordova, webView);
-    pluginStreetView.mapCtrl = CordovaGoogleMaps.this;
-    pluginStreetView.self = pluginStreetView;
-
     PluginEntry pluginEntry = new PluginEntry(mapId, pluginStreetView);
     pluginManager.addService(pluginEntry);
 
+    pluginStreetView.mapCtrl = CordovaGoogleMaps.this;
+    pluginStreetView.self = pluginStreetView;
+    
     pluginStreetView.getPanorama(args, callbackContext);
   }
 

--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -613,9 +613,6 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
       plugins.put(pluginName, pluginEntry);
       mapCtrl.pluginManager.addService(pluginEntry);
 
-      plugin.privateInitialize(pluginName, cordova, webView, null);
-
-      plugin.initialize(cordova, webView);
       ((MyPluginInterface)plugin).setPluginMap(PluginMap.this);
       MyPlugin myPlugin = (MyPlugin) plugin;
       myPlugin.self = (MyPlugin)plugin;
@@ -666,8 +663,6 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
       pluginMap = PluginMap.this;
       pluginMap.mapCtrl.pluginManager.addService(pluginEntry);
 
-      plugin.privateInitialize(className, cordova, webView, null);
-      plugin.initialize(cordova, webView);
       ((MyPluginInterface)plugin).setPluginMap(PluginMap.this);
       pluginEntry.plugin.execute("create", args, callbackContext);
 

--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -497,6 +497,11 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
     });
   }
 
+  /*
+   //***************************************************************************
+   // Google Maps SDK for Android v3 beta causes crash for these processes.
+   // Tmporally commented out
+   //***************************************************************************
   @Override
   public void onStart() {
     super.onStart();
@@ -531,6 +536,7 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
     }
     //mapCtrl.mPluginLayout.addPluginOverlay(PluginMap.this);
   }
+  */
 
   private class AdjustInitCamera implements Runnable {
     private JSONObject mParams;

--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -497,11 +497,6 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
     });
   }
 
-  /*
-   //***************************************************************************
-   // Google Maps SDK for Android v3 beta causes crash for these processes.
-   // Tmporally commented out
-   //***************************************************************************
   @Override
   public void onStart() {
     super.onStart();
@@ -536,7 +531,6 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
     }
     //mapCtrl.mPluginLayout.addPluginOverlay(PluginMap.this);
   }
-  */
 
   private class AdjustInitCamera implements Runnable {
     private JSONObject mParams;


### PR DESCRIPTION
Fix https://github.com/mapsplugin/cordova-plugin-googlemaps/issues/2871

From AGP 4.1.+ assert keyword/statements are enabled by the compile through code rewrite.

Which is causing PluginMap to fail

The issue is caused by PluginMap being initialised 2 times. The 2nd time it is initialised, CordovaPlugin.privateInitialize has assert to prevent this.

This PR removes initialising the PluginMap in CordovaGoogleMaps.getMap, because when it is added to PluginManager it will be initialised then.

NOTE

Although the relevant code in PluginManager and CordovaPlugin has not been changed for many years.
The plugin's codebase works for older cordova-android versions because they use older AGP.

In these older versions, assert keyword/statement do nothing