### PR TITLE
multiple_maps - Android: Fix: uses-sdk:minSdkVersion 19 cannot be smaller than version 21 decl…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -155,7 +155,7 @@
       <preference name="BackgroundColor" value="0"/>
 
       <!-- for this plugin -->
-      <preference name="android-minSdkVersion" value="19"/>
+      <preference name="android-minSdkVersion" value="21"/>
     </config-file>
 
     <config-file target="res/xml/config.xml" parent="/*">


### PR DESCRIPTION
…ared in library [androidx.core:core-splashscreen:1.0.0]

In plugin.xml "android-minSdkVersion" ist set to 19 for the config.xml and must be set to 21, because the referenced Library "androidx.core:core-splashscreen:1.0.0" defines minSdkVersion to 21. Both cannot live side by side.
