### PR TITLE
feat:  option to add mapId when using browser maps

### DIFF
--- a/src/browser/PluginMap.js
+++ b/src/browser/PluginMap.js
@@ -137,6 +137,11 @@ function PluginMap(mapId, options) {
     };
 
     if (options) {
+
+      if (options.mapId) {
+        mapInitOptions.mapId = options.mapId;
+      }
+
       if (options.mapType) {
         mapInitOptions.mapTypeId = MAP_TYPES[options.mapType];
       }

--- a/src/browser/PluginMarkerCluster.js
+++ b/src/browser/PluginMarkerCluster.js
@@ -512,13 +512,16 @@ function ClusterIconClass(options) {
   self.set('opacity', 0);
 
   iconMarker.bindTo('opacity', labelMarker);
-  iconMarker.bindTo('visible', labelMarker);
-  iconMarker.bindTo('position', labelMarker);
-  iconMarker.bindTo('map', labelMarker);
   self.bindTo('opacity', iconMarker);
-  self.bindTo('visible', iconMarker);
-  self.bindTo('map', iconMarker);
-  self.bindTo('position', iconMarker);
+
+  labelMarker.bindTo('visible', self);
+  iconMarker.bindTo('visible', self);
+
+  labelMarker.bindTo('position', self);
+  iconMarker.bindTo('position', self);
+
+  labelMarker.bindTo('map', self);
+  iconMarker.bindTo('map', self);
   self.set('labelMarkerAnchor', new google.maps.Point(canvas.width / 2, canvas.height / 2));
 
   self.addListener('icon_changed', function() {
@@ -687,7 +690,8 @@ ClusterIconClass.prototype.draw = function() {
         'anchor': self.get('labelMarkerAnchor')
       });
       setTimeout(function() {
-        self.set('opacity', 1);
+        const labelMarker = self.get('labelMarker');
+        labelMarker.set('opacity', 1);
       }, 10);
     });
 


### PR DESCRIPTION
Hello, since Google Maps pricing already includes the SKU: [Dynamic Maps (with or without a map ID using the Maps JavaScript API)](https://developers.google.com/maps/billing-and-pricing/sku-details#dynamic-maps-ess-sku),
and with the latest JS SDK the plugin’s tilt option doesn’t work because [WebGL (Vector maps) requires a map ID](https://developers.google.com/maps/documentation/javascript/map-ids/mapid-over),

users should have the option to include one.

Sorry if this should not have been submitted as a separate PR.