### PR TITLE
fix(ios): take styles option into account when initializing the map

### DIFF
--- a/src/ios/GoogleMaps/CordovaGoogleMaps.m
+++ b/src/ios/GoogleMaps/CordovaGoogleMaps.m
@@ -346,29 +346,45 @@
         
         viewCtrl.view = viewCtrl.map;
 
-        //mapType
-        NSString *typeStr = [initOptions valueForKey:@"mapType"];
-        
-        if (typeStr) {
-            NSDictionary *mapTypes = [NSDictionary dictionaryWithObjectsAndKeys:
-                                      ^() {return kGMSTypeHybrid; }, @"MAP_TYPE_HYBRID",
-                                      ^() {return kGMSTypeSatellite; }, @"MAP_TYPE_SATELLITE",
-                                      ^() {return kGMSTypeTerrain; }, @"MAP_TYPE_TERRAIN",
-                                      ^() {return kGMSTypeNormal; }, @"MAP_TYPE_NORMAL",
-                                      ^() {return kGMSTypeNone; }, @"MAP_TYPE_NONE",
-                                      nil];
+        // mapType and styles
+        NSString *styles = [initOptions valueForKey:@"styles"];
 
-            typedef GMSMapViewType (^CaseBlock)(void);
-            GMSMapViewType mapType;
-            CaseBlock caseBlock = mapTypes[typeStr];
-            
-            if (caseBlock) {
-                // Change the map type
-                mapType = caseBlock();
+        if (styles) {
+            NSError *error;
+            GMSMapStyle *mapStyle =
+                [GMSMapStyle styleWithJSONString:styles error:&error];
 
+            if (mapStyle != nil) {
                 [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-                    ((GMSMapView *)(viewCtrl.view)).mapType = mapType;
+                    ((GMSMapView *)viewCtrl.view).mapStyle = mapStyle;
                 }];
+            } else {
+                NSLog(@"Your specified map style is incorrect : %@",
+                      error.description);
+            }
+        } else {
+            NSString *typeStr = [initOptions valueForKey:@"mapType"];
+
+            if (typeStr) {
+                NSDictionary *mapTypes = @{
+                    @"MAP_TYPE_HYBRID"    : ^{ return kGMSTypeHybrid; },
+                    @"MAP_TYPE_SATELLITE" : ^{ return kGMSTypeSatellite; },
+                    @"MAP_TYPE_TERRAIN"   : ^{ return kGMSTypeTerrain; },
+                    @"MAP_TYPE_NORMAL"    : ^{ return kGMSTypeNormal; },
+                    @"MAP_TYPE_NONE"      : ^{ return kGMSTypeNone; }
+                };
+
+                typedef GMSMapViewType (^CaseBlock)(void);
+
+                CaseBlock caseBlock = mapTypes[typeStr];
+
+                if (caseBlock) {
+                    GMSMapViewType mapType = caseBlock();
+
+                    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+                        ((GMSMapView *)viewCtrl.view).mapType = mapType;
+                    }];
+                }
             }
         }
         


### PR DESCRIPTION
When using a custom style, map was first rendered with the default style and then redraw to apply the custom style option. Now, thanks to this fix, the styles option is taken into account during the initialization process.

Side note: using a custom style prevent from using a different map type than default.