### PR TITLE
Add null checks for map initialization

### DIFF
--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -458,6 +458,11 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
                 PluginMap.this.resizeMap(args, new PluginUtil.MyCallbackContext("dummy-" + map.hashCode(), webView) {
                   @Override
                   public void onResult(PluginResult pluginResult) {
+                    if (mapView == null || map == null) {
+                      // map removed before initialization is finished
+                      callbackContext.success();
+                      return;
+                    }
 
                     if (initCameraBounds != null) {
                       map.setOnCameraIdleListener(new GoogleMap.OnCameraIdleListener() {


### PR DESCRIPTION
Add null checks for mapView and map before initialization.

This will fix a bug that crashes the app sometimes.